### PR TITLE
Implement LoadGen RegisterIssueQueryThread()

### DIFF
--- a/loadgen/BUILD.gn
+++ b/loadgen/BUILD.gn
@@ -17,6 +17,8 @@ public_headers = [
 ]
 
 lib_sources = [
+  "issue_query_controller.cc",
+  "issue_query_controller.h",
   "loadgen.cc",
   "logging.cc",
   "logging.h",

--- a/loadgen/CMakeLists.txt
+++ b/loadgen/CMakeLists.txt
@@ -34,6 +34,7 @@ execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/version
 set(SOURCE
   ${CMAKE_CURRENT_SOURCE_DIR}/bindings/c_api.h
   ${CMAKE_CURRENT_SOURCE_DIR}/bindings/c_api.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/issue_query_controller.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/loadgen.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/logging.cc
   ${CMAKE_CURRENT_SOURCE_DIR}/logging.h

--- a/loadgen/benchmark/README.md
+++ b/loadgen/benchmark/README.md
@@ -7,3 +7,4 @@ Experiments:
 - Basic SUT + jemalloc: 800-900k i/s (`bash run.sh 800000 0`)
 - Queued SUT (2 complete threads) + jemalloc: 1.2-1.3M i/s (`bash run.sh 1200000 1 2 2048`)
 - Queued SUT (2 complete threads) + jemalloc + server_coalesce_queries: 1.4-1.5M is/ (`bash run.sh 1400000 1 2 512 1`)
+- Basic SUT + jemalloc + server_coalesce_queries + 4 IssueQueryThreads: 2.4-2.5M is/ (`bash run.sh 2400000 0 2 512 1 4`)

--- a/loadgen/benchmark/repro.cpp
+++ b/loadgen/benchmark/repro.cpp
@@ -53,7 +53,7 @@ class BasicSUT : public mlperf::SystemUnderTest {
   void IssueQuery(const std::vector<mlperf::QuerySample>& samples) override {
     int n = samples.size();
     if (n > mResponses.size()) {
-      std::cout << "Warning: reallocating response buffer in BasicSUT. Maybe "
+      std::cerr << "Warning: reallocating response buffer in BasicSUT. Maybe "
                    "you should initResponse with larger value!?"
                 << std::endl;
       initResponse(samples.size());
@@ -281,7 +281,7 @@ int main(int argc, char** argv) {
     if (useQueue) {
       std::cout << "Using MultiQueueSUT with " << numCompleteThreads
                 << " complete threads" << std::endl;
-      std::cout << "!!!! MultiQueueSUT is NOT implemented yet !!!!"
+      std::cerr << "!!!! MultiQueueSUT is NOT implemented yet !!!!"
                 << std::endl;
       return 1;
       // sut.reset(new MultiQueueSUT(num_issue_threads, numCompleteThreads,

--- a/loadgen/benchmark/run.sh
+++ b/loadgen/benchmark/run.sh
@@ -18,4 +18,4 @@ cd loadgen_build && cmake ../.. && make -j && cd ..
 echo "Building test program..."
 if [ ! -e build ]; then mkdir build; fi;
 g++ --std=c++11 -O3 -I.. -o build/repro.exe repro.cpp -Lloadgen_build -lmlperf_loadgen -lpthread && \
-LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 build/repro.exe $1 $2 $3 $4 $5
+LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 build/repro.exe $1 $2 $3 $4 $5 $6

--- a/loadgen/benchmark/run_debug.sh
+++ b/loadgen/benchmark/run_debug.sh
@@ -18,4 +18,4 @@ cd loadgen_build && cmake -DCMAKE_BUILD_TYPE=Debug ../.. && make -j && cd ..
 echo "Building test program in Debug mode..."
 if [ ! -e build ]; then mkdir build; fi;
 g++ --std=c++11 -O0 -g -I.. -o build/repro.exe repro.cpp -Lloadgen_build -lmlperf_loadgen -lpthread && \
-gdb --args build/repro.exe $1 $2 $3 $4 $5
+gdb --args build/repro.exe $1 $2 $3 $4 $5 $6

--- a/loadgen/bindings/c_api.cc
+++ b/loadgen/bindings/c_api.cc
@@ -153,5 +153,7 @@ void QuerySamplesComplete(QuerySampleResponse* responses,
   mlperf::QuerySamplesComplete(responses, response_count);
 }
 
+void RegisterIssueQueryThread() { mlperf::RegisterIssueQueryThread(); }
+
 }  // namespace c
 }  // namespace mlperf

--- a/loadgen/bindings/c_api.h
+++ b/loadgen/bindings/c_api.h
@@ -71,8 +71,11 @@ void DestroyQSL(void* qsl);
 /// point.
 void StartTest(void* sut, void* qsl, const TestSettings& settings);
 
-/// \brief TODO
-/// \details TODO
+///
+/// \brief Register a thread for query issuing in Server scenario.
+/// \details This is the C entry point. See mlperf::RegisterIssueQueryThread for the C++ entry
+/// point.
+///
 void RegisterIssueQueryThread();
 
 }  // namespace c

--- a/loadgen/bindings/c_api.h
+++ b/loadgen/bindings/c_api.h
@@ -71,6 +71,10 @@ void DestroyQSL(void* qsl);
 /// point.
 void StartTest(void* sut, void* qsl, const TestSettings& settings);
 
+/// \brief TODO
+/// \details TODO
+void RegisterIssueQueryThread();
+
 }  // namespace c
 }  // namespace mlperf
 

--- a/loadgen/issue_query_controller.cc
+++ b/loadgen/issue_query_controller.cc
@@ -1,0 +1,548 @@
+/* Copyright 2019 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/// \file
+/// \brief TODO
+
+#include "issue_query_controller.h"
+
+namespace mlperf {
+
+void RegisterIssueQueryThread() {
+  loadgen::IssueQueryController::GetInstance().RegisterThread();
+}
+
+/// \brief Loadgen implementation details.
+namespace loadgen {
+
+QueryMetadata::QueryMetadata(
+    const std::vector<QuerySampleIndex>& query_sample_indices,
+    std::chrono::nanoseconds scheduled_delta,
+    ResponseDelegate* response_delegate, SequenceGen* sequence_gen)
+    : scheduled_delta(scheduled_delta),
+      response_delegate(response_delegate),
+      sequence_id(sequence_gen->NextQueryId()),
+      wait_count_(query_sample_indices.size()) {
+  samples_.reserve(query_sample_indices.size());
+  for (QuerySampleIndex qsi : query_sample_indices) {
+    samples_.push_back({this, sequence_gen->NextSampleId(), qsi,
+                        sequence_gen->NextAccLogRng()});
+  }
+  query_to_send.reserve(query_sample_indices.size());
+  for (auto& s : samples_) {
+    query_to_send.push_back({reinterpret_cast<ResponseId>(&s), s.sample_index});
+  }
+}
+
+QueryMetadata::QueryMetadata(QueryMetadata&& src)
+    : query_to_send(std::move(src.query_to_send)),
+      scheduled_delta(src.scheduled_delta),
+      response_delegate(src.response_delegate),
+      sequence_id(src.sequence_id),
+      wait_count_(src.samples_.size()),
+      samples_(std::move(src.samples_)) {
+  // The move constructor should only be called while generating a
+  // vector of QueryMetadata, before it's been used.
+  // Assert that wait_count_ is in its initial state.
+  assert(src.wait_count_.load() == samples_.size());
+  // Update the "parent" of each sample to be this query; the old query
+  // address will no longer be valid.
+  // TODO: Only set up the sample parenting once after all the queries have
+  //       been created, rather than re-parenting on move here.
+  for (size_t i = 0; i < samples_.size(); i++) {
+    SampleMetadata* s = &samples_[i];
+    s->query_metadata = this;
+    query_to_send[i].id = reinterpret_cast<ResponseId>(s);
+  }
+}
+
+void QueryMetadata::NotifyOneSampleCompleted(PerfClock::time_point timestamp) {
+  size_t old_count = wait_count_.fetch_sub(1, std::memory_order_relaxed);
+  if (old_count == 1) {
+    all_samples_done_time = timestamp;
+    all_samples_done_.set_value();
+    response_delegate->QueryComplete();
+  }
+}
+
+void QueryMetadata::WaitForAllSamplesCompleted() {
+  all_samples_done_.get_future().wait();
+}
+
+PerfClock::time_point QueryMetadata::WaitForAllSamplesCompletedWithTimestamp() {
+  all_samples_done_.get_future().wait();
+  return all_samples_done_time;
+}
+
+// When server_coalesce_queries is set to true in Server scenario, we
+// sometimes coalesce multiple queries into one query. This is done by moving
+// the other query's sample into current query, while maintaining their
+// original scheduled_time.
+void QueryMetadata::CoalesceQueries(QueryMetadata* queries, size_t first,
+                                    size_t last, size_t stride) {
+  // Copy sample data over to current query, boldly assuming that each query
+  // only has one sample.
+  auto prev_scheduled_time = scheduled_time;
+  query_to_send.reserve((last - first) / stride +
+                        2);  // Extra one for the current query.
+  for (size_t i = first; i <= last; i += stride) {
+    auto& q = queries[i];
+    auto& s = q.samples_[0];
+    query_to_send.push_back({reinterpret_cast<ResponseId>(&s), s.sample_index});
+    q.scheduled_time = prev_scheduled_time + q.scheduled_delta;
+    q.issued_start_time = issued_start_time;
+    prev_scheduled_time = q.scheduled_time;
+  }
+}
+
+void QueryMetadata::Decoalesce() { query_to_send.resize(1); }
+
+/// \brief A base template that should never be used since each scenario has
+/// its own specialization.
+template <TestScenario scenario>
+struct QueryScheduler {
+  static_assert(scenario != scenario, "Unhandled TestScenario");
+};
+
+/// \brief Schedules queries for issuance in the single stream scenario.
+template <>
+struct QueryScheduler<TestScenario::SingleStream> {
+  QueryScheduler(const TestSettingsInternal& /*settings*/,
+                 const PerfClock::time_point) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    auto tracer = MakeScopedTracer([](AsyncTrace& trace) { trace("Waiting"); });
+    if (prev_query != nullptr) {
+      prev_query->WaitForAllSamplesCompleted();
+    }
+    prev_query = next_query;
+
+    auto now = PerfClock::now();
+    next_query->scheduled_time = now;
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  QueryMetadata* prev_query = nullptr;
+};
+
+/// \brief Schedules queries for issuance in the multi stream scenario.
+template <>
+struct QueryScheduler<TestScenario::MultiStream> {
+  QueryScheduler(const TestSettingsInternal& settings,
+                 const PerfClock::time_point start)
+      : qps(settings.target_qps),
+        max_async_queries(settings.max_async_queries),
+        start_time(start) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    {
+      prev_queries.push(next_query);
+      auto tracer =
+          MakeScopedTracer([](AsyncTrace& trace) { trace("Waiting"); });
+      if (prev_queries.size() > max_async_queries) {
+        prev_queries.front()->WaitForAllSamplesCompleted();
+        prev_queries.pop();
+      }
+    }
+
+    {
+      auto tracer =
+          MakeScopedTracer([](AsyncTrace& trace) { trace("Scheduling"); });
+      // TODO(brianderson): Skip ticks based on the query complete time,
+      //     before the query synchronization + notification thread hop,
+      //     rather than after.
+      PerfClock::time_point now = PerfClock::now();
+      auto i_period_old = i_period;
+      PerfClock::time_point tick_time;
+      do {
+        i_period++;
+        tick_time =
+            start_time + SecondsToDuration<PerfClock::duration>(i_period / qps);
+        Log([tick_time](AsyncLog& log) {
+          log.TraceAsyncInstant("QueryInterval", 0, tick_time);
+        });
+      } while (tick_time < now);
+      next_query->scheduled_intervals = i_period - i_period_old;
+      next_query->scheduled_time = tick_time;
+      std::this_thread::sleep_until(tick_time);
+    }
+
+    auto now = PerfClock::now();
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  size_t i_period = 0;
+  double qps;
+  const size_t max_async_queries;
+  PerfClock::time_point start_time;
+  std::queue<QueryMetadata*> prev_queries;
+};
+
+/// \brief Schedules queries for issuance in the single stream free scenario.
+template <>
+struct QueryScheduler<TestScenario::MultiStreamFree> {
+  QueryScheduler(const TestSettingsInternal& settings,
+                 const PerfClock::time_point /*start*/)
+      : max_async_queries(settings.max_async_queries) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    bool schedule_time_needed = true;
+    {
+      prev_queries.push(next_query);
+      auto tracer =
+          MakeScopedTracer([](AsyncTrace& trace) { trace("Waiting"); });
+      if (prev_queries.size() > max_async_queries) {
+        next_query->scheduled_time =
+            prev_queries.front()->WaitForAllSamplesCompletedWithTimestamp();
+        schedule_time_needed = false;
+        prev_queries.pop();
+      }
+    }
+
+    auto now = PerfClock::now();
+    if (schedule_time_needed) {
+      next_query->scheduled_time = now;
+    }
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  const size_t max_async_queries;
+  std::queue<QueryMetadata*> prev_queries;
+};
+
+/// \brief Schedules queries for issuance in the server scenario.
+template <>
+struct QueryScheduler<TestScenario::Server> {
+  QueryScheduler(const TestSettingsInternal& /*settings*/,
+                 const PerfClock::time_point start)
+      : start(start) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    auto tracer =
+        MakeScopedTracer([](AsyncTrace& trace) { trace("Scheduling"); });
+
+    auto scheduled_time = start + next_query->scheduled_delta;
+    next_query->scheduled_time = scheduled_time;
+
+    auto now = PerfClock::now();
+    if (now < scheduled_time) {
+      std::this_thread::sleep_until(scheduled_time);
+      now = PerfClock::now();
+    }
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  const PerfClock::time_point start;
+};
+
+/// \brief Schedules queries for issuance in the offline scenario.
+template <>
+struct QueryScheduler<TestScenario::Offline> {
+  QueryScheduler(const TestSettingsInternal& /*settings*/,
+                 const PerfClock::time_point start)
+      : start(start) {}
+
+  PerfClock::time_point Wait(QueryMetadata* next_query) {
+    next_query->scheduled_time = start;
+    auto now = PerfClock::now();
+    next_query->issued_start_time = now;
+    return now;
+  }
+
+  const PerfClock::time_point start;
+};
+
+IssueQueryController& IssueQueryController::GetInstance() {
+  static IssueQueryController instance;
+  return instance;
+}
+
+void IssueQueryController::RegisterThread() {
+  auto thread_id = std::this_thread::get_id();
+  size_t thread_idx{0};
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    thread_idx = thread_ids.size();
+    thread_ids.emplace_back(thread_id);
+  }
+
+  LogDetail([thread_id, thread_idx](AsyncDetail& detail) {
+    detail("Registered IssueQueryThread[" + std::to_string(thread_idx) +
+               "]. thread ID : ",
+           std::to_string(std::hash<std::thread::id>()(thread_id)));
+  });
+
+  while (true) {
+    // Wait until the main thread signals a start or the end.
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      cond_var.wait(lock, [this]() { return issuing || end_test; });
+      if (end_test) {
+        break;
+      }
+    }
+
+    // Start issuing queries.
+    if (thread_idx <= num_threads) {
+      IssueQueriesInternal<TestScenario::Server, true>(num_threads, thread_idx);
+      {
+        std::lock_guard<std::mutex> lock(mtx);
+        thread_complete[thread_idx] = true;
+      }
+      cond_var.notify_all();
+    }
+
+    // Wait until all issue threads complete.
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      cond_var.wait(lock, [this]() { return !issuing; });
+    }
+  }
+}
+
+void IssueQueryController::SetNumThreads(size_t n) {
+  std::unique_lock<std::mutex> lock(mtx);
+  const std::chrono::seconds timeout(10);
+  num_threads = n;
+  cond_var.wait_for(lock, timeout,
+                    [this]() { return num_threads == thread_ids.size(); });
+  if (num_threads != thread_ids.size()) {
+    LogDetail([this](AsyncDetail& detail) {
+      detail.Error(
+          "Mismatch between settings and number of registered ",
+          "IssueQueryThreads! settings.server_num_issue_query_threads = ",
+          num_threads, " but ", thread_ids.size(), " threads registered.");
+    });
+  }
+}
+
+template <TestScenario scenario>
+void IssueQueryController::StartIssueQueries(IssueQueryState* s) {
+  state = s;
+  state->start_for_power = std::chrono::system_clock::now();
+  state->start_time = PerfClock::now();
+  if (scenario != TestScenario::Server || num_threads == 0) {
+    IssueQueriesInternal<scenario, false>(1, 0);
+  } else {
+    // Tell all issue threads to start issuing queries.
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      issuing = true;
+      thread_complete.assign(num_threads, false);
+    }
+    cond_var.notify_all();
+    // Wait until all issue threads complete.
+    {
+      std::unique_lock<std::mutex> lock(mtx);
+      cond_var.wait(lock, [this]() {
+        return std::all_of(thread_complete.begin(), thread_complete.end(),
+                           [](bool in) { return in; });
+      });
+      issuing = false;
+    }
+    cond_var.notify_all();
+  }
+}
+
+template void IssueQueryController::StartIssueQueries<
+    TestScenario::MultiStream>(IssueQueryState* s);
+template void IssueQueryController::StartIssueQueries<
+    TestScenario::MultiStreamFree>(IssueQueryState* s);
+template void IssueQueryController::StartIssueQueries<TestScenario::Offline>(
+    IssueQueryState* s);
+template void IssueQueryController::StartIssueQueries<TestScenario::Server>(
+    IssueQueryState* s);
+template void IssueQueryController::StartIssueQueries<
+    TestScenario::SingleStream>(IssueQueryState* s);
+
+void IssueQueryController::EndThreads() {
+  // Tell all the issue threads to end.
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    end_test = true;
+  }
+  cond_var.notify_all();
+}
+
+template <TestScenario scenario, bool multi_thread>
+void IssueQueryController::IssueQueriesInternal(size_t query_stride,
+                                                size_t thread_idx) {
+  auto sut = state->sut;
+  auto& queries = *state->queries;
+  auto& response_logger = *state->response_delegate;
+  size_t queries_issued = 0;
+  size_t queries_issued_per_iter = 0;
+  size_t queries_count = queries.size();
+
+  // Calculate the min/max queries per issue thread.
+  const auto& settings = *state->settings;
+  const size_t min_query_count = settings.min_query_count;
+  const size_t min_query_count_for_thread =
+      (thread_idx < (min_query_count % query_stride))
+          ? (min_query_count / query_stride + 1)
+          : (min_query_count / query_stride);
+  const size_t max_query_count = settings.max_query_count;
+  const size_t max_query_count_for_thread =
+      (thread_idx < (max_query_count % query_stride))
+          ? (max_query_count / query_stride + 1)
+          : (max_query_count / query_stride);
+
+  // Create query scheduler.
+  const auto start = state->start_time;
+  QueryScheduler<scenario> query_scheduler(settings, start);
+  auto last_now = start;
+
+  // We can never run out of generated queries in the server scenario,
+  // since the duration depends on the scheduled query time and not
+  // the actual issue time.
+  bool ran_out_of_generated_queries = scenario != TestScenario::Server;
+  size_t expected_latencies = 0;
+  for (size_t queries_idx = thread_idx; queries_idx < queries_count;
+       queries_idx += query_stride) {
+    queries_issued_per_iter = 0;
+    auto& query = queries[queries_idx];
+    auto tracer1 =
+        MakeScopedTracer([](AsyncTrace& trace) { trace("SampleLoop"); });
+    last_now = query_scheduler.Wait(&query);
+
+    // If in Server scenario and server_coalesce_queries is enabled, multiple
+    // queries are coalesed into one big query if the current time has already
+    // passed the scheduled time of multiple queries.
+    if (scenario == TestScenario::Server &&
+        settings.requested.server_coalesce_queries) {
+      auto current_query_idx = queries_idx;
+      auto scheduled_time = query.scheduled_time;
+      for (; queries_idx + query_stride < queries_count;
+           queries_idx += query_stride) {
+        auto next_scheduled_time =
+            scheduled_time +
+            queries[queries_idx + query_stride].scheduled_delta;
+        if (last_now < next_scheduled_time) {
+          break;
+        }
+        scheduled_time = next_scheduled_time;
+        queries_issued_per_iter++;
+      }
+      if (queries_idx > current_query_idx) {
+        query.CoalesceQueries(queries.data(), current_query_idx + query_stride,
+                              queries_idx, query_stride);
+      }
+    }
+
+    // Issue the query to the SUT.
+    {
+      auto tracer3 =
+          MakeScopedTracer([](AsyncTrace& trace) { trace("IssueQuery"); });
+      sut->IssueQuery(query.query_to_send);
+    }
+
+    expected_latencies += query.query_to_send.size();
+    queries_issued_per_iter++;
+    queries_issued += queries_issued_per_iter;
+
+    if (scenario == TestScenario::Server &&
+        settings.requested.server_coalesce_queries) {
+      // Set the query back to its clean state.
+      query.Decoalesce();
+    }
+
+    if (state->mode == TestMode::AccuracyOnly) {
+      // TODO: Rate limit in accuracy mode so accuracy mode works even
+      //       if the expected/target performance is way off.
+      continue;
+    }
+
+    auto duration = (last_now - start);
+    if (scenario == TestScenario::Server) {
+      if (settings.max_async_queries != 0) {
+        size_t queries_issued_total{0};
+        if (multi_thread) {
+          // To check actual number of async queries, we would have to combine
+          // the number of queries_issued from all issue threads.
+          {
+            std::lock_guard<std::mutex> lock(state->mtx);
+            state->queries_issued += queries_issued_per_iter;
+            queries_issued_total = state->queries_issued;
+          }
+        } else {
+          queries_issued_total = queries_issued;
+        }
+        size_t queries_outstanding =
+            queries_issued_total -
+            response_logger.queries_completed.load(std::memory_order_relaxed);
+        if (queries_outstanding > settings.max_async_queries) {
+          LogDetail([thread_idx, queries_issued_total,
+                     queries_outstanding](AsyncDetail& detail) {
+            detail.Error("IssueQueryThread ", std::to_string(thread_idx),
+                         " Ending early: Too many outstanding queries.",
+                         "issued", std::to_string(queries_issued_total),
+                         "outstanding", std::to_string(queries_outstanding));
+          });
+          break;
+        }
+      }
+    } else {
+      if (queries_issued >= min_query_count_for_thread &&
+          duration >= settings.target_duration) {
+        LogDetail([thread_idx](AsyncDetail& detail) {
+          detail(
+              " Ending naturally: Minimum query count and test duration met.");
+        });
+        ran_out_of_generated_queries = false;
+        break;
+      }
+    }
+
+    if (settings.max_query_count != 0 &&
+        queries_issued >= max_query_count_for_thread) {
+      LogDetail([thread_idx, queries_issued](AsyncDetail& detail) {
+        detail.Error("IssueQueryThread ", std::to_string(thread_idx),
+                     " Ending early: Max query count reached.", "query_count",
+                     std::to_string(queries_issued));
+      });
+      ran_out_of_generated_queries = false;
+      break;
+    }
+
+    if (settings.max_duration.count() != 0 &&
+        duration > settings.max_duration) {
+      LogDetail([thread_idx, duration](AsyncDetail& detail) {
+        detail.Error("IssueQueryThread ", std::to_string(thread_idx),
+                     " Ending early: Max test duration reached.", "duration_ns",
+                     std::to_string(duration.count()));
+      });
+      ran_out_of_generated_queries = false;
+      break;
+    }
+  }
+
+  // Combine the issuing statistics from multiple issue threads.
+  {
+    std::lock_guard<std::mutex> lock(state->mtx);
+    state->ran_out_of_generated_queries |= ran_out_of_generated_queries;
+    // In Server scenario and when max_async_queries != 0, we would have set
+    // state->queries_issued when we check max_async_queries in the loop.
+    if (!(scenario == TestScenario::Server && settings.max_async_queries != 0 &&
+          multi_thread)) {
+      state->queries_issued += queries_issued;
+    }
+    state->expected_latencies += expected_latencies;
+  }
+}
+
+}  // namespace loadgen
+
+}  // namespace mlperf

--- a/loadgen/issue_query_controller.h
+++ b/loadgen/issue_query_controller.h
@@ -1,0 +1,173 @@
+/* Copyright 2019 The MLPerf Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+/// \file
+/// \brief TODO
+
+#ifndef MLPERF_LOADGEN_ISSUE_QUERY_CONTROLLER_H_
+#define MLPERF_LOADGEN_ISSUE_QUERY_CONTROLLER_H_
+
+#include "loadgen.h"
+#include "logging.h"
+#include "query_sample.h"
+#include "system_under_test.h"
+#include "test_settings_internal.h"
+#include "utils.h"
+
+#include <stdint.h>
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <queue>
+#include <random>
+#include <thread>
+#include <vector>
+
+namespace mlperf {
+
+namespace loadgen {
+
+struct SampleMetadata;
+class QueryMetadata;
+
+/// \brief Every query and sample within a call to StartTest gets a unique
+/// sequence id for easy cross reference, and a random number which is used to
+/// determine accuracy logging when it is enabled.
+struct SequenceGen {
+  uint64_t NextQueryId() { return query_id++; }
+  uint64_t NextSampleId() { return sample_id++; }
+  uint64_t CurrentSampleId() { return sample_id; }
+  double NextAccLogRng() { return accuracy_log_dist(accuracy_log_rng); }
+  void InitAccLogRng(uint64_t accuracy_log_rng_seed) {
+    accuracy_log_rng = std::mt19937(accuracy_log_rng_seed);
+  }
+
+ private:
+  uint64_t query_id = 0;
+  uint64_t sample_id = 0;
+  std::mt19937 accuracy_log_rng;
+  std::uniform_real_distribution<double> accuracy_log_dist =
+      std::uniform_real_distribution<double>(0, 1);
+};
+
+/// \brief An interface for a particular scenario + mode to implement for
+/// extended hanlding of sample completion.
+struct ResponseDelegate {
+  virtual ~ResponseDelegate() = default;
+  virtual void SampleComplete(SampleMetadata*, QuerySampleResponse*,
+                              PerfClock::time_point) = 0;
+  virtual void QueryComplete() = 0;
+  std::atomic<size_t> queries_completed{0};
+};
+
+/// \brief Used by the loadgen to coordinate response data and completion.
+struct SampleMetadata {
+  QueryMetadata* query_metadata;
+  uint64_t sequence_id;
+  QuerySampleIndex sample_index;
+  double accuracy_log_val;
+};
+
+/// \brief Maintains data and timing info for a query and all its samples.
+class QueryMetadata {
+ public:
+  QueryMetadata(const std::vector<QuerySampleIndex>& query_sample_indices,
+                std::chrono::nanoseconds scheduled_delta,
+                ResponseDelegate* response_delegate, SequenceGen* sequence_gen);
+  QueryMetadata(QueryMetadata&& src);
+
+  void NotifyOneSampleCompleted(PerfClock::time_point timestamp);
+
+  void WaitForAllSamplesCompleted();
+
+  PerfClock::time_point WaitForAllSamplesCompletedWithTimestamp();
+
+  // When server_coalesce_queries is set to true in Server scenario, we
+  // sometimes coalesce multiple queries into one query. This is done by moving
+  // the other query's sample into current query, while maintaining their
+  // original scheduled_time.
+  void CoalesceQueries(QueryMetadata* queries, size_t first, size_t last,
+                       size_t stride);
+
+  void Decoalesce();
+
+ public:
+  std::vector<QuerySample> query_to_send;
+  const std::chrono::nanoseconds scheduled_delta;
+  ResponseDelegate* const response_delegate;
+  const uint64_t sequence_id;
+
+  // Performance information.
+
+  size_t scheduled_intervals = 0;  // Number of intervals between queries, as
+                                   // actually scheduled during the run.
+                                   // For the multi-stream scenario only.
+  PerfClock::time_point scheduled_time;
+  PerfClock::time_point issued_start_time;
+  PerfClock::time_point all_samples_done_time;
+
+ private:
+  std::atomic<size_t> wait_count_;
+  std::promise<void> all_samples_done_;
+  std::vector<SampleMetadata> samples_;
+};
+
+struct IssueQueryState {
+  SystemUnderTest* sut;
+  std::vector<QueryMetadata>* queries;
+  ResponseDelegate* response_delegate;
+  const TestSettingsInternal* settings;
+  TestMode mode;
+  std::chrono::system_clock::time_point start_for_power;
+  PerfClock::time_point start_time;
+  bool ran_out_of_generated_queries;
+  size_t queries_issued;
+  size_t expected_latencies;
+  std::mutex mtx;
+};
+
+/// \brief TODO
+class IssueQueryController {
+ public:
+  static IssueQueryController& GetInstance();
+  IssueQueryController(IssueQueryController const&) = delete;
+  void operator=(IssueQueryController const&) = delete;
+  void RegisterThread();
+  void SetNumThreads(size_t n);
+  template <TestScenario scenario>
+  void StartIssueQueries(IssueQueryState* s);
+  void EndThreads();
+
+ private:
+  /// \note Hide constructor so that it cannot be explicitly created.
+  IssueQueryController() {}
+  template <TestScenario scenario, bool multi_thread>
+  void IssueQueriesInternal(size_t query_stride, size_t thread_idx);
+
+  IssueQueryState* state;
+  std::mutex mtx;
+  std::condition_variable cond_var;
+  std::vector<std::thread::id> thread_ids;
+  size_t num_threads{0};
+  bool issuing{false};
+  std::vector<bool> thread_complete;
+  bool end_test{false};
+};
+
+}  // namespace loadgen
+
+}  // namespace mlperf
+
+#endif  // MLPERF_LOADGEN_ISSUE_QUERY_CONTROLLER_H_

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -59,8 +59,13 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const LogSettings& log_settings);
 
 ///
-/// \brief TODO
-/// \details TODO
+/// \brief Register a thread for query issuing in Server scenario.
+/// \details If a thread registers itself, the thread(s) is used to call SUT's
+/// IssueQuery(). This function is blocking until the entire test is done. The
+/// number of registered threads must match server_num_issue_query_threads in
+/// TestSettings. This function only has effect in Server scenario.
+/// This is the C++ entry point. See mlperf::c::RegisterIssueQueryThread for the
+/// C entry point.
 ///
 void RegisterIssueQueryThread();
 

--- a/loadgen/loadgen.h
+++ b/loadgen/loadgen.h
@@ -58,6 +58,12 @@ void StartTest(SystemUnderTest* sut, QuerySampleLibrary* qsl,
                const TestSettings& requested_settings,
                const LogSettings& log_settings);
 
+///
+/// \brief TODO
+/// \details TODO
+///
+void RegisterIssueQueryThread();
+
 /// @}
 
 }  // namespace mlperf

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -211,7 +211,10 @@ struct TestSettings {
   /// out from a performance run. Useful for performance tuning and speeding up
   /// the FindPeakPerformance mode.
   uint64_t server_max_async_queries = 0;  ///< 0: Infinity.
-  /// \brief TODO
+  /// \brief The number of issue query threads that will be registered and used
+  /// to call SUT's IssueQuery(). If this is 0, the same thread calling
+  /// StartTest() will be used to call IssueQuery(). See also
+  /// mlperf::RegisterIssueQueryThread().
   uint64_t server_num_issue_query_threads = 0;
   /**@}*/
 

--- a/loadgen/test_settings.h
+++ b/loadgen/test_settings.h
@@ -211,6 +211,8 @@ struct TestSettings {
   /// out from a performance run. Useful for performance tuning and speeding up
   /// the FindPeakPerformance mode.
   uint64_t server_max_async_queries = 0;  ///< 0: Infinity.
+  /// \brief TODO
+  uint64_t server_num_issue_query_threads = 0;
   /**@}*/
 
   // ==================================

--- a/loadgen/test_settings_internal.cc
+++ b/loadgen/test_settings_internal.cc
@@ -79,8 +79,10 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.server_target_qps >= 0.0) {
         target_qps = requested.server_target_qps;
       } else {
-        LogDetail([server_target_qps = requested.server_target_qps,
-                   target_qps = target_qps](AsyncDetail &detail) {
+        LogDetail([
+          server_target_qps = requested.server_target_qps,
+          target_qps = target_qps
+        ](AsyncDetail & detail) {
           detail.Error("Invalid value for server_target_qps requested.",
                        "requested", server_target_qps, "using", target_qps);
         });
@@ -94,8 +96,10 @@ TestSettingsInternal::TestSettingsInternal(
       if (requested.offline_expected_qps >= 0.0) {
         target_qps = requested.offline_expected_qps;
       } else {
-        LogDetail([offline_expected_qps = requested.offline_expected_qps,
-                   target_qps = target_qps](AsyncDetail &detail) {
+        LogDetail([
+          offline_expected_qps = requested.offline_expected_qps,
+          target_qps = target_qps
+        ](AsyncDetail & detail) {
           detail.Error("Invalid value for offline_expected_qps requested.",
                        "requested", offline_expected_qps, "using", target_qps);
         });
@@ -138,22 +142,23 @@ TestSettingsInternal::TestSettingsInternal(
   // Validate TestSettings
   if (requested.performance_issue_same &&
       (requested.performance_issue_same_index >= performance_sample_count)) {
-    LogDetail(
-        [performance_issue_same_index = requested.performance_issue_same_index,
-         performance_sample_count =
-             performance_sample_count](AsyncDetail &detail) {
-          detail.Error(
-              "Sample Idx to be repeated in performance_issue_same mode"
-              " cannot be greater than loaded performance_sample_count.",
-              "performance_issue_same_index", performance_issue_same_index,
-              "performance_sample_count", performance_sample_count);
-        });
+    LogDetail([
+      performance_issue_same_index = requested.performance_issue_same_index,
+      performance_sample_count = performance_sample_count
+    ](AsyncDetail & detail) {
+      detail.Error(
+          "Sample Idx to be repeated in performance_issue_same mode"
+          " cannot be greater than loaded performance_sample_count.",
+          "performance_issue_same_index", performance_issue_same_index,
+          "performance_sample_count", performance_sample_count);
+    });
   }
 
   if (requested.performance_issue_unique && requested.performance_issue_same) {
-    LogDetail([performance_issue_unique = requested.performance_issue_unique,
-               performance_issue_same =
-                   requested.performance_issue_same](AsyncDetail &detail) {
+    LogDetail([
+      performance_issue_unique = requested.performance_issue_unique,
+      performance_issue_same = requested.performance_issue_same
+    ](AsyncDetail & detail) {
       detail.Error(
           "Performance_issue_unique and performance_issue_same, both"
           " cannot be true at the same time.",
@@ -233,6 +238,8 @@ void LogRequestedTestSettings(const TestSettings &s) {
         detail("server_find_peak_qps_boundary_step_size : ",
                s.server_find_peak_qps_boundary_step_size);
         detail("server_max_async_queries : ", s.server_max_async_queries);
+        detail("server_num_issue_query_threads : ",
+               s.server_num_issue_query_threads);
         break;
       case TestScenario::Offline:
         detail("offline_expected_qps : ", s.offline_expected_qps);
@@ -260,7 +267,7 @@ void LogRequestedTestSettings(const TestSettings &s) {
 }
 
 void TestSettingsInternal::LogEffectiveSettings() const {
-  LogDetail([s = *this](AsyncDetail &detail) {
+  LogDetail([s = *this](AsyncDetail & detail) {
     detail("");
     detail("Effective Settings:");
 
@@ -358,7 +365,8 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
     }
     // if we get here, found will be set
     if (val_l) {
-      *val_l = strtoull(found.c_str(), nullptr, 0) * static_cast<uint64_t>(multiplier);
+      *val_l = strtoull(found.c_str(), nullptr, 0) *
+               static_cast<uint64_t>(multiplier);
     }
     if (val_d) *val_d = strtod(found.c_str(), nullptr) * multiplier;
     return true;
@@ -370,7 +378,7 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
   int line_nr = 0;
   int errors = 0;
   if (!fss.is_open()) {
-    LogDetail([p = path](AsyncDetail &detail) {
+    LogDetail([p = path](AsyncDetail & detail) {
       detail.Error("can't open file ", p);
     });
     return -ENOENT;
@@ -400,14 +408,14 @@ int TestSettings::FromConfig(const std::string &path, const std::string &model,
           continue;
         }
         errors++;
-        LogDetail([l = line_nr](AsyncDetail &detail) {
+        LogDetail([l = line_nr](AsyncDetail & detail) {
           detail.Error("value needs to be integer or double, line=", l);
         });
         break;
       }
       if (looking_for == 1 && s != "=") {
         errors++;
-        LogDetail([l = line_nr](AsyncDetail &detail) {
+        LogDetail([l = line_nr](AsyncDetail & detail) {
           detail.Error("expected 'key=value', line=", l);
         });
         break;


### PR DESCRIPTION
This is built on top of: https://github.com/mlperf/inference/pull/618

Changes:
- Added a new TestSettings flag: `server_num_issue_query_threads`.
- Implemented multi-thread IssueQuery() functionality in `issue_query_controller.cc/h`. This feature is enabled only when in Server scenario, `server_num_issue_query_threads` is set to positive numbers, and if there are threads calling `RegisterIssueQueryThread()`.
- Moved `SampleMetadata`, `QueryMetadata`, `ResponseDelegate`, `QueryScheduler` implementations and part of `IssueQueries()` to `issue_query_controller.cc/h` with very minor modifications.
